### PR TITLE
Allow setting the default directory for the resource bundle

### DIFF
--- a/Base/LocaleUtil.php
+++ b/Base/LocaleUtil.php
@@ -10,6 +10,7 @@
     const LOCALE_PATTERN = "/(^[^_-]*)(?:[_-]([^_-]*)(?:[_-]([^_-]*))?)?/";
 
     protected static $defaultLocale;
+    protected static $resourceBundleDir = __DIR__;
 
     public static function setDefaultLocale($defaultLocale)
     {
@@ -25,9 +26,14 @@
       return self::$defaultLocale;
     }
 
+    public static function setResourceBundleDir($directory)
+    {
+      self::$resourceBundleDir = $directory;
+    }
+
     public static function getLocalizedMessageFromBundle($bundleName, $key, $locale)
     {
-      $bundleName = str_replace(__NAMESPACE__ . "\\", __DIR__ . DIRECTORY_SEPARATOR, $bundleName);
+      $bundleName = str_replace(__NAMESPACE__ . "\\", self::$resourceBundleDir . DIRECTORY_SEPARATOR, $bundleName);
       $rb = ResourceBundle::create($locale, $bundleName , TRUE);
       if (!($rb instanceof ResourceBundle))
       {

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The usage is nearly similar to that of the [java library](https://developers.goo
     - `DataSourceHelper::parseQuery($string)` - Returns a `Query` object from $string
     - `Util\Pdo\MySqlPdoDataSourceHelper::executeQuery(Query $query, PDO $pdo, $tableNmae)` - Returns a `DataTable` object by applying the query to a MySQL table 
     - `DataSourceHelper::applyQuery(Query $query, DataTable $dataTable, $locale)` - Returns a `DataTable` object by applying the query to an exsiting `DataTable`
+- Optionally the resource bundle can be kept in a folder outside of the repository. In that case call `Google\Visualization\DataSource\Base\LocaleUtil::setResourceBundleDir($pathToResources);` where `ErrorMessages` is a sub-folder of `$pathToResources`.
 
 
 Examples


### PR DESCRIPTION
Not sure what you think about this one. It helps me in my project where I need to compile the resources separately and keep them outside of my vendor folder (I install ```google-visualization-php``` using composer).
That way I can initialise LocaleUtil during bootstrapping of my framework:

```
use Google\Visualization\DataSource\Base\LocaleUtil;
LocaleUtil::setResourceBundleDir(app_path() . '/config/packages/bggardner/Base');
```