### PR TITLE
Avoid division by zero errors

### DIFF
--- a/Util/Pdo/PostgresqlPdoDataSourceHelper.php
+++ b/Util/Pdo/PostgresqlPdoDataSourceHelper.php
@@ -401,6 +401,10 @@
         {
           $columnIds[] = self::getColumnId($column);
         }
+        // Avoid Division by zero errors in postgres by setting denominator to null if it's zero
+        if ($operator == '/') {
+          $columnIds[1] = '(CASE (' . $columnIds[1] . ') WHEN 0 THEN NULL ELSE (' . $columnIds[1] . ') END)';
+        }
         $columnId = "(" . implode(" " . $operator . " ", $columnIds) . ")";
       } else
       {


### PR DESCRIPTION
This one is a bit more hairy. It solves the problem of division by zero throwing an error in postgresql, and instead makes sure division by zero gives ```null```, just like it does in mysql.

It helps with queries like:
```
select something, sum(clicks) / sum(leads) group by something;
```

It does so by altering the denominator:
```
select something, sum(clicks) / (CASE sum(leads) WHEN 0 THEN NULL ELSE sum(leads) END) group by something;
```